### PR TITLE
Add a simple dashboard page for viewing just backouts

### DIFF
--- a/app/templates/backouts.html
+++ b/app/templates/backouts.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<head>
+  <title>Firefox Backouts</title>
+  <link rel="stylesheet" type="text/css" href="/static/stylesheets/main.css">
+</head>
+<body>
+	
+{{ backout_markup }}
+
+</body>

--- a/app/views.py
+++ b/app/views.py
@@ -2,11 +2,10 @@ import datetime
 from datetime import timedelta
 import re
 
-from flask import render_template, request
+from flask import Markup, render_template, request
 from app import app
 
 import tree_controller
-
 
 @app.route('/')
 @app.route('/index')
@@ -64,7 +63,117 @@ def index():
         tree=tree, status={"status": status, "status_reason":status_reason}, uptime=uptime, intermittent_count_last_week=intermittent_count_last_week,
         intermittent_count_closed_last_week=intermittent_count_closed_last_week)
 
+# Backouts Dashboard
+@app.route('/backouts.html')
+def backouts():
+	tree = request.args.get('tree', 'mozilla-central')
+	period = request.args.get('w', 4)
+	now = datetime.datetime.now()
+	backouts_list = []
+	
+	for i in range(1,int(period)):
+		timespan = now - timedelta(i*7)
+		y = timespan.year
+		m = timespan.month if timespan.month > 9 else "0%s" % timespan.month
+		d = timespan.day if timespan.day > 9 else "0%s" % timespan.day
+		delta = "%s-%s-%s" % (y, m, d)
+		backouts_list.append(tree_controller.backouts_list(tree, delta))
+		
+	backout_markup = getBackoutMarkup(backouts_list, tree)
+	return render_template("backouts.html", backout_markup=backout_markup)
 
+def checkForBackouts(aPushlog):
+    # total number of pushes in the log for today
+    today_pushes = 0 
+	
+    # Regular expressions to search for backouts
+    regex_backouts = [re.compile('^.*[b,B]ackout.*'),
+                      re.compile('^.*[b,B]acked out.*'),
+		      re.compile('^.*[b,B]ack out.*')]
+                      
+    # List of backouts by folder
+    backouts_by_folder = {}
+    
+    if aPushlog is not None: 
+	
+	# Iterate through each of the pushes
+	for resp in aPushlog['pushes']:
+	    timestamp = int(aPushlog['pushes'][resp]['date'])
+	    pushDate = datetime.date.fromtimestamp(timestamp)
+	    	    
+	    # Check if the push is from today
+	    if (pushDate == datetime.date.today()):
+		today_pushes += 1
 
+		# Iterate through the changesets and check if any are a backout
+		for chnge in range(len(aPushlog['pushes'][resp]['changesets'])):
+		    changeset = aPushlog['pushes'][resp]['changesets'][chnge]
+		    print changeset['desc']
+                    if (regex_backouts[0].match(changeset['desc']) or
+                        regex_backouts[1].match(changeset['desc']) or
+                        regex_backouts[2].match(changeset['desc'])):
+			print "XXX BACKOUT FOUND! XXX"
 
+                        if (pushDate == datetime.date.today()):
+                            backed += 1
+                            backouts_by_folder = countBackoutsByFolder(backouts_by_folder, changeset)  
+                        
+                            break
+    
+    return backouts_by_folder		
 
+def countBackoutsByFolder(backouts_by_folder, changeset):
+    # List of possible folders from hg.mozilla.org/mozilla-central [this should be dynamically generated in the future]
+    folders = ["accessibile", "addon-sdk", "b2g", "browser", "build", "caps", "chrome", "config", "content", "db sqlite3", "docshell", "dom", "editor",
+               "embedding", "extensions", "gfx", "hal", "image", "intl", "ipc", "js", "layout", "media", "memory", "mfbt", "mobile", "modules", "mozglue",
+               "netwerk", "nsprpub", "other-licenses", "parser", "probes", "profile", "python", "rdf", "security", "services", "startupcache", "storage", 
+               "testing", "toolkit", "tools", "uriloader", "view", "webapprt", "widget", "xpcom", "xpfe", "xulrunner"]
+               	
+    for fo in folders:
+        backouts_by_folder[fo] = 0
+
+        # Regular expression to search for file folder
+        searchString = re.compile('^' + fo + '.*')
+			  
+        # Iterate through each file indicated in the backout
+        for f in range(len(changeset['files'])):
+		
+            # Check if the folder is found in the file path
+            if (searchString.match(changeset['files'][f])):
+				
+                # Increase the backout count for that folder
+                backouts_by_folder[fo] += 1
+                
+    return backouts_by_folder
+	
+def getBackoutMarkup(aBackoutsList, aTree):
+
+	html = "<table style='border:1px solid #000000; font-family:Arial'>"
+	
+	# Table Headings
+	html += "<tr>"
+	html += "<th>&nbsp;</th>"
+	for b in aBackoutsList:
+		html += "<th>" + b['startdate'] + "</th>"
+	html += "</tr>"
+	
+	components = aBackoutsList[0]['backouts_list'].keys()
+	
+	i = 0
+	for c in sorted(components):
+		if ((i%2) == 0):
+			html += "<tr style='background:#bbd9f7'>"
+		else:
+			html += "<tr style='background:#f9f9c5'>"
+		html += "<td>" + c + "</td>"
+		for b in aBackoutsList:
+			for k, v in sorted(b['backouts_list'].iteritems()):
+				if (c == k):
+					html += "<td>" + str(v) + "</td>"
+			
+		html += "</tr>"
+		i += 1
+	
+	html += "</table>"
+    
+	return Markup(html)

--- a/venv/include/python2.7
+++ b/venv/include/python2.7
@@ -1,0 +1,1 @@
+/usr/include/python2.7

--- a/venv/include/python2.7
+++ b/venv/include/python2.7
@@ -1,1 +1,0 @@
-/usr/include/python2.7


### PR DESCRIPTION
I've added a page and the necessary functions to display a table of backouts week-over-week. The table counts the number of files touched in the top-level folders. The code is pretty rough right now but I'm wondering if it's useful to contribute back to futurama-data.

Feel free to pull my branch and test it (use the same instructions as futurama-data but load backouts.html instead of index.html).